### PR TITLE
Expand interpretability gameplay and persistence

### DIFF
--- a/src/mech_arena/enemy.py
+++ b/src/mech_arena/enemy.py
@@ -1,21 +1,33 @@
-"""Enemy logic with simple behaviour and interpretability metadata."""
+"""Enemy logic with behaviour tied to interpretability concepts."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, Tuple
 
 try:  # pragma: no cover - pygame may not be installed during unit tests
     import pygame
 except Exception:  # pragma: no cover - allow running tests without pygame
     pygame = None  # type: ignore[assignment]
 
+if False:  # pragma: no cover - type checking only
+    from .level import Level
+
 from .player import Player
+
+
+def _distance(a: Tuple[float, float], b: Tuple[float, float]) -> float:
+    return math.hypot(a[0] - b[0], a[1] - b[1])
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
 
 
 @dataclass
 class Enemy:
-    """Enemy entity that drifts toward the player."""
+    """Enemy entity whose behaviour reflects its underlying circuit."""
 
     x: float
     y: float
@@ -26,18 +38,154 @@ class Enemy:
     health: int = 3
     damage: int = 1
     colour: tuple[int, int, int] = (244, 96, 137)
+    archetype: str | None = None
+    support_charge: float = field(default=0.0, init=False)
+    activation: float = field(default=0.0, init=False)
+    ablated: bool = field(default=False, init=False)
+    induction_index: int = field(default=0, init=False)
+    circuit_charge: float = field(default=0.0, init=False)
+    analysis_notes: Dict[str, str] = field(default_factory=dict, init=False)
 
-    def update(self, player: Player, dt: float) -> None:
-        """Move toward the player's current position."""
+    def __post_init__(self) -> None:
+        if self.archetype is None:
+            self.archetype = self.topic
+
+    # ------------------------------------------------------------------
+    # Core behaviour
+    # ------------------------------------------------------------------
+    def update(self, level: "Level", dt: float) -> None:
+        """Advance the enemy based on its interpretability role."""
+
+        self.support_charge = max(0.0, self.support_charge - dt * 0.4)
+        self.activation = max(0.0, self.activation - dt * 0.6)
+        self.analysis_notes.clear()
+
+        if self.ablated:
+            self.activation = max(0.0, self.activation - dt * 2)
+            return
+
+        archetype = (self.archetype or self.topic).lower()
+        if "residual" in archetype:
+            self._update_residual(level, dt)
+        elif "induction" in archetype:
+            self._update_induction(level, dt)
+        elif "circuit" in archetype or "breaker" in archetype:
+            self._update_circuit(level, dt)
+        else:
+            self._drift_toward(level.player, dt)
+
+    def _drift_toward(
+        self, player: Player, dt: float, speed_scale: float = 1.0
+    ) -> None:
         dx = player.x - self.x
         dy = player.y - self.y
-        distance = (dx**2 + dy**2) ** 0.5 or 1.0
-        self.x += (dx / distance) * self.speed * dt
-        self.y += (dy / distance) * self.speed * dt
+        distance = math.hypot(dx, dy) or 1.0
+        velocity = self.speed * (1.0 + 0.65 * self.support_charge) * speed_scale
+        self.x += (dx / distance) * velocity * dt
+        self.y += (dy / distance) * velocity * dt
 
+    # ------------------------------------------------------------------
+    # Behaviour specialisations
+    # ------------------------------------------------------------------
+    def _update_residual(self, level: "Level", dt: float) -> None:
+        player = level.player
+        allies = [ally for ally in level.living_enemies if ally is not self]
+        if allies:
+            avg_x = sum(ally.x for ally in allies) / len(allies)
+            avg_y = sum(ally.y for ally in allies) / len(allies)
+            target = ((player.x + avg_x) / 2, (player.y + avg_y) / 2)
+        else:
+            target = (player.x, player.y)
+        self._move_towards(target, dt, speed_scale=0.75)
+
+        for ally in allies:
+            dist = _distance(self.center, ally.center)
+            if dist < 260:
+                ally.receive_support(0.6 * dt)
+                level.register_link(
+                    self, ally, intensity=_clamp(1.0 - dist / 260, 0.2, 1.0)
+                )
+                level.analysis_tags["residual_linking"] = True
+        if allies:
+            self.analysis_notes["Links"] = str(len(allies))
+        self.analysis_notes["Support"] = f"{self.support_charge:.1f}"
+        self.activation = _clamp(self.activation + 0.8 * dt, 0.0, 1.5)
+        self.analysis_notes["Role"] = "Buffering allied activations"
+
+    def _update_induction(self, level: "Level", dt: float) -> None:
+        marker = level.token_marker_for(self.induction_index)
+        self.analysis_notes["Predicting"] = marker.label
+        self.analysis_notes["Step"] = (
+            f"{self.induction_index + 1}/{level.token_cycle_length}"
+        )
+        target = marker.position
+        self._move_towards(target, dt, speed_scale=1.05)
+        level.register_prediction(self, marker)
+        if _distance(self.center, target) < marker.radius + self.size * 0.25:
+            self.induction_index = (self.induction_index + 1) % level.token_cycle_length
+            level.analysis_tags["induction_prediction"] = True
+        self.activation = _clamp(self.activation + 0.7 * dt, 0.0, 1.2)
+
+    def _update_circuit(self, level: "Level", dt: float) -> None:
+        player = level.player
+        allies = [ally for ally in level.living_enemies if ally is not self]
+        if allies:
+            focus = min(allies, key=lambda ally: _distance(self.center, ally.center))
+            target = ((focus.x + player.x) / 2, (focus.y + player.y) / 2)
+            dist = _distance(self.center, focus.center)
+            if dist < 220:
+                self.circuit_charge += dt
+                intensity = _clamp(1.0 - dist / 220, 0.2, 1.0)
+                level.register_link(
+                    self, focus, intensity=intensity, colour=(255, 150, 120)
+                )
+                level.analysis_tags["circuit_chain"] = True
+                if self.circuit_charge > 2.4:
+                    level.trigger_circuit_burst(self, focus)
+                    self.circuit_charge = 0.0
+            else:
+                self.circuit_charge = max(0.0, self.circuit_charge - dt)
+        else:
+            target = (player.x, player.y)
+
+        self._move_towards(target, dt, speed_scale=0.9)
+        self.activation = _clamp(
+            self.activation + (self.circuit_charge + 0.2) * dt, 0.0, 1.5
+        )
+        self.analysis_notes["Charge"] = f"{self.circuit_charge:0.1f}s"
+
+    def _move_towards(
+        self, target: Tuple[float, float], dt: float, speed_scale: float = 1.0
+    ) -> None:
+        tx, ty = target
+        dx = tx - self.x
+        dy = ty - self.y
+        distance = math.hypot(dx, dy) or 1.0
+        velocity = self.speed * (1.0 + 0.65 * self.support_charge) * speed_scale
+        self.x += (dx / distance) * velocity * dt
+        self.y += (dy / distance) * velocity * dt
+
+    # ------------------------------------------------------------------
+    # Combat helpers
+    # ------------------------------------------------------------------
     def take_damage(self, amount: int) -> None:
         """Reduce the enemy's health."""
         self.health = max(0, self.health - amount)
+
+    def receive_support(self, strength: float) -> None:
+        self.support_charge = _clamp(self.support_charge + strength, 0.0, 2.0)
+
+    def toggle_ablation(self) -> None:
+        self.ablated = not self.ablated
+        if self.ablated:
+            self.activation = 0.0
+
+    # ------------------------------------------------------------------
+    # Geometry helpers
+    # ------------------------------------------------------------------
+    @property
+    def center(self) -> Tuple[float, float]:
+        return (self.x + self.size / 2, self.y + self.size / 2)
 
     @property
     def rect(self) -> Any:

--- a/src/mech_arena/game.py
+++ b/src/mech_arena/game.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Tuple
+from dataclasses import dataclass, field
+from typing import List, Tuple
 
 import pygame
 
@@ -22,6 +22,7 @@ class InputState:
     move: Tuple[float, float] = (0.0, 0.0)
     fire_target: Tuple[float, float] | None = None
     trigger_scan: bool = False
+    analysis_commands: List[Tuple[str, int]] = field(default_factory=list)
 
 
 class Game:
@@ -73,6 +74,7 @@ class Game:
                 move=inputs.move,
                 fire_target=inputs.fire_target,
                 trigger_scan=inputs.trigger_scan,
+                analysis_commands=inputs.analysis_commands,
             )
             self._draw()
         pygame.quit()
@@ -81,14 +83,22 @@ class Game:
         move_x = move_y = 0.0
         fire_target: Tuple[float, float] | None = None
         trigger_scan = False
+        analysis_commands: List[Tuple[str, int]] = []
 
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 self.running = False
             elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
                 fire_target = event.pos
-            elif event.type == pygame.KEYDOWN and event.key == pygame.K_TAB:
-                trigger_scan = True
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_TAB:
+                    trigger_scan = True
+                elif pygame.K_1 <= event.key <= pygame.K_9:
+                    index = event.key - pygame.K_1
+                    if event.mod & pygame.KMOD_SHIFT:
+                        analysis_commands.append(("pulse_patch", index))
+                    else:
+                        analysis_commands.append(("toggle_ablation", index))
 
         keys = pygame.key.get_pressed()
         if keys[pygame.K_w] or keys[pygame.K_UP]:
@@ -109,7 +119,10 @@ class Game:
             fire_target = pygame.mouse.get_pos()
 
         return InputState(
-            move=(move_x, move_y), fire_target=fire_target, trigger_scan=trigger_scan
+            move=(move_x, move_y),
+            fire_target=fire_target,
+            trigger_scan=trigger_scan,
+            analysis_commands=analysis_commands,
         )
 
     def _draw(self) -> None:

--- a/src/mech_arena/level.py
+++ b/src/mech_arena/level.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, Deque, Dict, Iterable, List, Tuple
@@ -13,7 +14,30 @@ except Exception:  # pragma: no cover - fallback when pygame is missing
 
 from .enemy import Enemy
 from .player import Player
+from .progression import ResearchJournal
 from .projectile import Projectile
+from .tasks import ResearchTask, build_tasks_for
+
+
+@dataclass
+class TokenMarker:
+    """Represents a token in a repeating induction pattern."""
+
+    label: str
+    anchor: Tuple[float, float]
+    orbit_radius: float = 110.0
+    phase_offset: float = 0.0
+    speed: float = 0.35
+    radius: float = 12.0
+    colour: Tuple[int, int, int] = (140, 210, 255)
+    glow_colour: Tuple[int, int, int] = (30, 60, 120)
+    position: Tuple[float, float] = field(default_factory=lambda: (0.0, 0.0))
+
+    def update(self, clock: float) -> None:
+        angle = (clock * self.speed + self.phase_offset) * 2 * math.pi
+        ox = math.cos(angle) * self.orbit_radius
+        oy = math.sin(angle) * self.orbit_radius * 0.55
+        self.position = (self.anchor[0] + ox, self.anchor[1] + oy)
 
 
 def rects_collide(a: Any, b: Any) -> bool:
@@ -48,12 +72,21 @@ class Insight:
 
 
 DEFAULT_KNOWLEDGE: Dict[str, str] = {
-    "Residual Stream": "Residual connections keep information flowing forward so that"
-    " attention and MLPs can remix context without forgetting earlier tokens.",
-    "Induction Head": "A pattern-matching attention head that copies the next token in a"
-    " repeated sequence—often the first structure people reverse-engineer.",
-    "Circuit Breaker": "A bundle of neurons whose joint activation implements a behaviour;"
-    " tracing it explains how features combine.",
+    "Residual Stream": (
+        "Residual connections keep information flowing so attention and MLP layers "
+        "can remix context without erasing earlier evidence. Watch how allied stats "
+        "collapse when you ablate this stream."
+    ),
+    "Induction Head": (
+        "Pattern-matching heads learn to copy the next token in repeated sequences. "
+        "Scanning reveals the beads of the sequence and how the head anticipates "
+        "its next target."
+    ),
+    "Circuit Breaker": (
+        "Bundles of neurons can interlock like a breaker circuit, firing only when "
+        "multiple pathways light up. When charged, they can cascade energy into "
+        "neighbours—unless you intervene."
+    ),
 }
 
 
@@ -70,13 +103,31 @@ class Level:
     insights: List[Insight] = field(default_factory=list, init=False)
     knowledge_log: List[Tuple[str, str]] = field(default_factory=list, init=False)
     messages: Deque[str] = field(default_factory=lambda: deque(maxlen=6), init=False)
+    coaching_tips: Deque[str] = field(
+        default_factory=lambda: deque(maxlen=3), init=False
+    )
     scan_timer: float = 0.0
     objective: str = "Stabilise the residual stream"
     background: Tuple[int, int, int] = (18, 20, 40)
+    research_journal: ResearchJournal = field(default_factory=ResearchJournal.load)
+    active_tasks: List[ResearchTask] = field(default_factory=list, init=False)
+    completed_tasks: List[ResearchTask] = field(default_factory=list, init=False)
+    analysis_links: List[
+        Tuple[Tuple[float, float], Tuple[float, float], Tuple[int, int, int], float]
+    ] = field(default_factory=list, init=False)
+    analysis_predictions: List[Tuple[Tuple[float, float], TokenMarker]] = field(
+        default_factory=list, init=False
+    )
+    analysis_tags: Dict[str, bool] = field(default_factory=dict, init=False)
+    token_markers: List[TokenMarker] = field(default_factory=list, init=False)
+    token_clock: float = field(default=0.0, init=False)
+    journal_dirty: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
         if not self.knowledge_base:
             self.knowledge_base = dict(DEFAULT_KNOWLEDGE)
+        self._init_token_markers()
+        self._seed_coaching_tips()
         self.add_message(f"Entering {self.name}: {self.description}")
 
     # ------------------------------------------------------------------
@@ -88,17 +139,28 @@ class Level:
         move: Tuple[float, float] = (0.0, 0.0),
         fire_target: Tuple[float, float] | None = None,
         trigger_scan: bool = False,
+        analysis_commands: Iterable[Tuple[str, int]] = (),
     ) -> None:
         """Advance the simulation by ``dt`` seconds."""
+        self.token_clock += dt
+        for marker in self.token_markers:
+            marker.update(self.token_clock)
+        self.analysis_links.clear()
+        self.analysis_predictions.clear()
+        self.analysis_tags.clear()
+
         self.player.move(*move, dt=dt)
         self.player.clamp_to_bounds(self.width - 280, self.height)
         self.player.update(dt)
 
         if trigger_scan and self.player.consume_scan_energy():
-            self.scan_timer = 2.5
-            self.add_message("Scan pulse: latent connections highlighted.")
+            self.scan_timer = 3.0
+            self.add_message("Scan pulse: latent topology slowed for analysis.")
         else:
             self.scan_timer = max(0.0, self.scan_timer - dt)
+
+        for command in analysis_commands:
+            self._handle_analysis_command(command)
 
         if fire_target is not None:
             projectile = self.player.try_fire(fire_target)
@@ -108,6 +170,40 @@ class Level:
         self._update_projectiles(dt)
         self._update_enemies(dt)
         self._check_insight_collection()
+        self._update_tasks()
+        if self.journal_dirty:
+            self.research_journal.save()
+            self.journal_dirty = False
+
+    def _init_token_markers(self) -> None:
+        if self.token_markers:
+            return
+        anchor = (self.width * 0.35, self.height * 0.45)
+        phases = [0.0, 0.33, 0.66]
+        labels = ["A", "B", "C"]
+        for phase, label in zip(phases, labels):
+            marker = TokenMarker(
+                label=label,
+                anchor=anchor,
+                orbit_radius=130.0,
+                phase_offset=phase,
+                speed=0.28,
+                radius=14.0,
+            )
+            marker.update(self.token_clock)
+            self.token_markers.append(marker)
+
+    def _seed_coaching_tips(self) -> None:
+        self.coaching_tips.clear()
+        self.coaching_tips.append(
+            "Tab: pause the fray and surface hidden residual links."
+        )
+        self.coaching_tips.append(
+            "Number keys: ablate a subsystem while the scan overlay is active."
+        )
+        self.coaching_tips.append(
+            "Shift + number: patch energy back in to observe recovery dynamics."
+        )
 
     def _update_projectiles(self, dt: float) -> None:
         remaining: List[Projectile] = []
@@ -135,7 +231,7 @@ class Level:
         for enemy in self.enemies:
             if enemy.health <= 0:
                 continue
-            enemy.update(self.player, dt * slow_factor)
+            enemy.update(self, dt * slow_factor)
             if rects_collide(enemy.rect, self.player.rect):
                 self.player.take_damage(enemy.damage)
                 self.add_message(f"Warning: {enemy.topic} inflicted damage!")
@@ -149,6 +245,12 @@ class Level:
                 insight.collected = True
                 self.knowledge_log.append((insight.title, insight.body))
                 self.add_message(f"Insight logged: {insight.title}")
+                self.research_journal.log_insight(insight.title, insight.body)
+                self.journal_dirty = True
+                self._activate_tasks(insight.title)
+                next_task = self._next_task_for(insight.title)
+                if next_task and next_task.tip:
+                    self.add_coaching_tip(next_task.tip)
         self.insights = [ins for ins in self.insights if not ins.collected]
 
     def _handle_enemy_defeated(self, enemy: Enemy) -> None:
@@ -161,12 +263,154 @@ class Level:
         )
         self.insights.append(insight)
         self.add_message(f"Subsystem neutralised: {enemy.topic}")
+        self.add_coaching_tip(
+            f"Collect the {enemy.topic} insight to unlock deeper experiments."
+        )
 
     def _inside_bounds(self, x: float, y: float) -> bool:
         return 0 <= x <= self.width - 280 and 0 <= y <= self.height
 
     def add_message(self, text: str) -> None:
         self.messages.appendleft(text)
+
+    def add_coaching_tip(self, text: str) -> None:
+        if text in self.coaching_tips:
+            return
+        self.coaching_tips.appendleft(text)
+
+    def _handle_analysis_command(self, command: Tuple[str, int]) -> None:
+        if not command:
+            return
+        action, index = command
+        enemy = self._enemy_by_analysis_index(index)
+        if enemy is None:
+            return
+        if action == "toggle_ablation":
+            if self.scan_timer <= 0.0:
+                self.add_message("Initiate a scan to run ablation experiments.")
+                return
+            enemy.toggle_ablation()
+            state = "ablated" if enemy.ablated else "restored"
+            self.add_message(f"{enemy.topic} {state} for analysis.")
+            tag = self._analysis_tag_key(enemy.topic, "ablation")
+            if enemy.ablated and tag:
+                self.analysis_tags[tag] = True
+                self.journal_dirty = True
+        elif action == "pulse_patch":
+            if self.scan_timer <= 0.0:
+                self.add_message("Need an active scan to patch activations.")
+                return
+            enemy.ablated = False
+            enemy.receive_support(0.8)
+            enemy.activation = min(enemy.activation + 0.5, 1.5)
+            self.add_message(f"Injected synthetic activation into {enemy.topic}.")
+            tag = self._analysis_tag_key(enemy.topic, "patch")
+            if tag:
+                self.analysis_tags[tag] = True
+
+    def _analysis_tag_key(self, topic: str, action: str) -> str | None:
+        lookup = {
+            ("Residual Stream", "ablation"): "residual_ablation",
+            ("Induction Head", "ablation"): "induction_ablation",
+            ("Circuit Breaker", "ablation"): "circuit_ablation",
+            ("Residual Stream", "patch"): "residual_patch",
+            ("Induction Head", "patch"): "induction_patch",
+            ("Circuit Breaker", "patch"): "circuit_patch",
+        }
+        return lookup.get((topic, action))
+
+    def register_link(
+        self,
+        source: Enemy,
+        target: Enemy,
+        intensity: float,
+        colour: Tuple[int, int, int] | None = None,
+    ) -> None:
+        if self.scan_timer <= 0.0:
+            return
+        if colour is None:
+            colour = (160, 255, 200)
+        self.analysis_links.append((source.center, target.center, colour, intensity))
+
+    def register_prediction(self, enemy: Enemy, marker: TokenMarker) -> None:
+        if self.scan_timer <= 0.0:
+            return
+        self.analysis_predictions.append((enemy.center, marker))
+
+    def trigger_circuit_burst(self, enemy: Enemy, partner: Enemy) -> None:
+        player_centre = self.player.center
+        enemy_centre = enemy.center
+        distance = math.hypot(
+            player_centre[0] - enemy_centre[0], player_centre[1] - enemy_centre[1]
+        )
+        if distance < 140:
+            self.player.take_damage(1)
+            self.add_message(
+                "Circuit breaker overload rattled the hull! Study the chain."
+            )
+        else:
+            self.add_message("Circuit breaker discharged; note the suppressed allies.")
+        self.analysis_tags["circuit_chain"] = True
+
+    def _activate_tasks(self, concept: str) -> None:
+        existing_ids = {task.identifier for task in self.active_tasks}
+        for task in build_tasks_for(concept):
+            if task.identifier in existing_ids:
+                continue
+            if task.identifier in self.research_journal.tasks_for(concept):
+                task.completed = True
+            if self.research_journal.is_mastered(concept):
+                task.completed = True
+            self.active_tasks.append(task)
+            if task.requires_scan:
+                self.add_coaching_tip(
+                    "Use scan mode to gather data for research tasks."
+                )
+
+    def _next_task_for(self, concept: str) -> ResearchTask | None:
+        for task in self.active_tasks:
+            if task.concept == concept and not task.completed:
+                return task
+        return None
+
+    def _update_tasks(self) -> None:
+        progress_made = False
+        for task in self.active_tasks:
+            if task.evaluate(self):
+                self.research_journal.mark_task_completed(task.concept, task.identifier)
+                self.add_message(f"Research breakthrough: {task.description}")
+                self.completed_tasks.append(task)
+                self.journal_dirty = True
+                progress_made = True
+        if progress_made:
+            for concept in {task.concept for task in self.active_tasks}:
+                concept_tasks = [t for t in self.active_tasks if t.concept == concept]
+                if concept_tasks and all(t.completed for t in concept_tasks):
+                    if not self.research_journal.is_mastered(concept):
+                        self.research_journal.mark_mastered(concept)
+                        self.journal_dirty = True
+                        self.add_message(f"Concept mastered: {concept}")
+
+    def _enemy_by_analysis_index(self, index: int) -> Enemy | None:
+        living = sorted(self.living_enemies, key=lambda e: e.topic)
+        if 0 <= index < len(living):
+            return living[index]
+        return None
+
+    def token_marker_for(self, index: int) -> TokenMarker:
+        if not self.token_markers:
+            self._init_token_markers()
+        if not self.token_markers:
+            raise ValueError("Token markers not initialised")
+        return self.token_markers[index % len(self.token_markers)]
+
+    @property
+    def token_cycle_length(self) -> int:
+        return max(1, len(self.token_markers))
+
+    @property
+    def living_enemies(self) -> List[Enemy]:
+        return [enemy for enemy in self.enemies if enemy.health > 0]
 
     # ------------------------------------------------------------------
     # Rendering
@@ -181,14 +425,31 @@ class Level:
         overlay_x = arena_width
 
         surface.fill(self.background)
+        self._draw_backdrop(surface, arena_width, height)
         self._draw_grid(surface, arena_width, height)
+        self._draw_token_stream(surface, font)
         self._draw_insights(surface)
         self._draw_projectiles(surface)
         self._draw_enemies(surface)
         self._draw_player(surface)
         if self.scan_timer > 0.0:
-            self._draw_scan_overlay(surface, arena_width, height)
+            self._draw_scan_overlay(surface, arena_width, height, font)
         self._draw_hud(surface, font, overlay_x, height)
+
+    def _draw_backdrop(self, surface: Any, arena_width: int, height: int) -> None:
+        if pygame is None:
+            return
+        cache = getattr(self, "_backdrop_cache", None)
+        if cache is None or cache.get_size() != (arena_width, height):
+            cache = pygame.Surface((arena_width, height))
+            for y in range(height):
+                ratio = y / max(1, height - 1)
+                r = int(18 + 45 * ratio)
+                g = int(20 + 70 * ratio)
+                b = int(40 + 110 * ratio)
+                pygame.draw.line(cache, (r, g, b), (0, y), (arena_width, y))
+            setattr(self, "_backdrop_cache", cache)
+        surface.blit(cache, (0, 0))
 
     def _draw_grid(self, surface: Any, arena_width: int, height: int) -> None:
         if pygame is None:
@@ -199,57 +460,233 @@ class Level:
         for y in range(0, height, 40):
             pygame.draw.line(surface, grid_colour, (0, y), (arena_width, y))
 
+    def _draw_token_stream(self, surface: Any, font: Any | None) -> None:
+        if pygame is None:
+            return
+        if font is None:
+            font = pygame.font.SysFont("Fira Code", 16)
+        for marker in self.token_markers:
+            x, y = marker.position
+            center = (int(x), int(y))
+            glow_size = int(marker.radius * 3)
+            glow_surface = pygame.Surface(
+                (glow_size * 2, glow_size * 2), pygame.SRCALPHA
+            )
+            pygame.draw.circle(
+                glow_surface,
+                (*marker.glow_colour, 80 if self.scan_timer > 0 else 40),
+                (glow_size, glow_size),
+                glow_size,
+            )
+            pygame.draw.circle(
+                glow_surface,
+                (*marker.colour, 220),
+                (glow_size, glow_size),
+                int(marker.radius),
+            )
+            surface.blit(glow_surface, (center[0] - glow_size, center[1] - glow_size))
+            label = font.render(marker.label, True, (230, 245, 255))
+            surface.blit(
+                label,
+                (
+                    center[0] - label.get_width() // 2,
+                    center[1] - label.get_height() // 2,
+                ),
+            )
+
     def _draw_player(self, surface: Any) -> None:
         if pygame is None:
             return
-        pygame.draw.rect(surface, (120, 200, 255), self.player.rect, border_radius=6)
+        rect = self.player.rect
+        glow = pygame.Surface((rect.width + 20, rect.height + 20), pygame.SRCALPHA)
+        pygame.draw.ellipse(glow, (90, 160, 255, 100), glow.get_rect())
+        surface.blit(glow, (rect.x - 10, rect.y - 10))
+        pygame.draw.rect(surface, (120, 200, 255), rect, border_radius=12)
+        inner = rect.inflate(-12, -12)
+        pygame.draw.rect(surface, (28, 40, 70), inner, border_radius=10)
+        # Visualise remaining energy as a luminous thruster bar.
+        ratio = self.player.energy / max(1.0, self.player.max_energy)
+        thruster_width = max(4, int(inner.width * ratio))
+        thruster_rect = pygame.Rect(
+            inner.x, inner.y + inner.height - 6, thruster_width, 4
+        )
+        pygame.draw.rect(surface, (120, 255, 220), thruster_rect, border_radius=2)
 
     def _draw_enemies(self, surface: Any) -> None:
         if pygame is None:
             return
         for enemy in self.enemies:
-            pygame.draw.rect(surface, enemy.colour, enemy.rect, border_radius=6)
+            rect = enemy.rect
+            activation = min(1.5, enemy.activation)
+            base = enemy.colour
+            tint = (
+                min(255, int(base[0] + 90 * activation)),
+                min(255, int(base[1] + 70 * activation)),
+                min(255, int(base[2] + 70 * activation)),
+            )
+            if enemy.support_charge > 0.1:
+                aura_size = rect.width + 22
+                aura = pygame.Surface((aura_size, aura_size), pygame.SRCALPHA)
+                pygame.draw.ellipse(
+                    aura,
+                    (120, 220, 200, int(120 * min(enemy.support_charge, 1.0))),
+                    aura.get_rect(),
+                )
+                surface.blit(aura, (rect.x - 11, rect.y - 11))
+            pygame.draw.rect(surface, tint, rect, border_radius=10)
+            core = rect.inflate(-12, -12)
+            core_colour = (35, 40, 72) if enemy.ablated else (255, 255, 255)
+            if enemy.ablated:
+                overlay = pygame.Surface((rect.width, rect.height), pygame.SRCALPHA)
+                overlay.fill((30, 40, 80, 160))
+                surface.blit(overlay, rect.topleft)
+                pygame.draw.rect(
+                    surface, (200, 220, 255), rect, width=2, border_radius=10
+                )
+                pygame.draw.rect(surface, core_colour, core, width=2, border_radius=8)
+            else:
+                pygame.draw.rect(surface, core_colour, core, border_radius=8)
+                if enemy.circuit_charge > 0.1:
+                    charge_ratio = min(1.0, enemy.circuit_charge / 2.4)
+                    charge_height = max(2, int(core.height * charge_ratio))
+                    charge_rect = pygame.Rect(
+                        core.x + core.width - 6,
+                        core.y + core.height - charge_height,
+                        4,
+                        charge_height,
+                    )
+                    pygame.draw.rect(surface, (255, 180, 120), charge_rect)
 
     def _draw_projectiles(self, surface: Any) -> None:
         if pygame is None:
             return
         for projectile in self.projectiles:
-            pygame.draw.circle(
-                surface,
-                projectile.color,
-                (int(projectile.x), int(projectile.y)),
-                projectile.radius,
+            pos = (int(projectile.x), int(projectile.y))
+            glow_size = projectile.radius * 3
+            glow_surface = pygame.Surface(
+                (glow_size * 2, glow_size * 2), pygame.SRCALPHA
             )
+            pygame.draw.circle(
+                glow_surface,
+                (*projectile.color, 90),
+                (glow_size, glow_size),
+                glow_size,
+            )
+            surface.blit(glow_surface, (pos[0] - glow_size, pos[1] - glow_size))
+            pygame.draw.circle(surface, projectile.color, pos, projectile.radius)
 
     def _draw_insights(self, surface: Any) -> None:
         if pygame is None:
             return
         for insight in self.insights:
+            pos = (int(insight.x), int(insight.y))
+            halo_size = insight.radius * 3
+            halo = pygame.Surface((halo_size * 2, halo_size * 2), pygame.SRCALPHA)
             pygame.draw.circle(
-                surface,
-                insight.colour,
-                (int(insight.x), int(insight.y)),
-                insight.radius,
-                width=2,
+                halo,
+                (*insight.colour, 70),
+                (halo_size, halo_size),
+                halo_size,
             )
+            pygame.draw.circle(
+                halo,
+                (*insight.colour, 180),
+                (halo_size, halo_size),
+                insight.radius,
+                width=3,
+            )
+            surface.blit(halo, (pos[0] - halo_size, pos[1] - halo_size))
 
-    def _draw_scan_overlay(self, surface: Any, arena_width: int, height: int) -> None:
+    def _draw_scan_overlay(
+        self, surface: Any, arena_width: int, height: int, font: Any | None
+    ) -> None:
         if pygame is None:
             return
         overlay = pygame.Surface((arena_width, height), pygame.SRCALPHA)
-        alpha = int(120 * (self.scan_timer / 2.5))
-        overlay.fill((80, 200, 255, max(40, alpha)))
+        alpha = int(140 * (self.scan_timer / 3.0))
+        overlay.fill((60, 130, 200, max(60, alpha)))
         surface.blit(overlay, (0, 0))
         player_center = (
             int(self.player.x + self.player.size / 2),
             int(self.player.y + self.player.size / 2),
         )
-        for enemy in self.enemies:
+        pulse = pygame.Surface((arena_width, height), pygame.SRCALPHA)
+        pygame.draw.circle(
+            pulse,
+            (120, 200, 255, 90),
+            player_center,
+            int(60 + 40 * math.sin(self.scan_timer * 4)),
+            width=2,
+        )
+        surface.blit(pulse, (0, 0))
+        for enemy in self.living_enemies:
             enemy_center = (
                 int(enemy.x + enemy.size / 2),
                 int(enemy.y + enemy.size / 2),
             )
-            pygame.draw.line(surface, (160, 255, 200), player_center, enemy_center, 2)
+            colour = (255, 170, 180) if enemy.ablated else (160, 255, 200)
+            width_line = 1 if enemy.ablated else 2
+            pygame.draw.line(surface, colour, player_center, enemy_center, width_line)
+
+        for start, end, colour, intensity in self.analysis_links:
+            start_pos = (int(start[0]), int(start[1]))
+            end_pos = (int(end[0]), int(end[1]))
+            pygame.draw.line(
+                surface,
+                colour,
+                start_pos,
+                end_pos,
+                max(1, int(3 * intensity)),
+            )
+
+        for source, marker in self.analysis_predictions:
+            start_pos = (int(source[0]), int(source[1]))
+            end_pos = (int(marker.position[0]), int(marker.position[1]))
+            pygame.draw.line(surface, (255, 220, 140), start_pos, end_pos, 2)
+            pygame.draw.circle(surface, (255, 220, 140), end_pos, 4)
+
+        self._draw_analysis_cards(surface, font, arena_width)
+
+    def _draw_analysis_cards(
+        self, surface: Any, font: Any | None, arena_width: int
+    ) -> None:
+        if pygame is None:
+            return
+        if font is None:
+            font = pygame.font.SysFont("Fira Code", 14)
+        for enemy in self.living_enemies:
+            info_lines = [enemy.topic]
+            for key, value in enemy.analysis_notes.items():
+                info_lines.append(f"{key}: {value}")
+            if enemy.support_charge > 0.05:
+                info_lines.append(f"Support: {enemy.support_charge:.1f}")
+            if enemy.circuit_charge > 0.05:
+                info_lines.append(f"Charge: {enemy.circuit_charge:.1f}s")
+            if enemy.ablated:
+                info_lines.append("Ablated — outputs silenced")
+            text_surfaces = [
+                font.render(line, True, (225, 235, 255)) for line in info_lines
+            ]
+            panel_width = max(
+                arena_width // 5, max(ts.get_width() for ts in text_surfaces) + 16
+            )
+            panel_height = sum(ts.get_height() for ts in text_surfaces) + 12
+            panel = pygame.Surface((panel_width, panel_height), pygame.SRCALPHA)
+            panel.fill((22, 34, 66, 210))
+            pygame.draw.rect(
+                panel, (120, 200, 255), panel.get_rect(), width=1, border_radius=6
+            )
+            cursor_y = 6
+            for rendered in text_surfaces:
+                panel.blit(
+                    rendered, ((panel_width - rendered.get_width()) // 2, cursor_y)
+                )
+                cursor_y += rendered.get_height() + 2
+            anchor_x = int(enemy.x + enemy.size / 2 - panel_width / 2)
+            anchor_y = int(enemy.y) - panel_height - 12
+            anchor_x = max(4, min(anchor_x, arena_width - panel_width - 4))
+            anchor_y = max(4, anchor_y)
+            surface.blit(panel, (anchor_x, anchor_y))
 
     def _draw_hud(
         self, surface: Any, font: Any | None, overlay_x: int, height: int
@@ -257,7 +694,8 @@ class Level:
         if pygame is None:
             return
         panel_rect = pygame.Rect(overlay_x, 0, surface.get_width() - overlay_x, height)
-        pygame.draw.rect(surface, (12, 13, 24), panel_rect)
+        pygame.draw.rect(surface, (14, 16, 28), panel_rect)
+        pygame.draw.rect(surface, (40, 48, 72), panel_rect, width=2)
         if font is None:
             font = pygame.font.SysFont("Fira Code", 16)
         text_y = 12
@@ -272,7 +710,39 @@ class Level:
             f"Objective: {self.objective}",
             (180, 200, 255),
         )
-        text_y += 8
+        scan_status = (
+            f"Scan active: {self.scan_timer:0.1f}s remaining"
+            if self.scan_timer > 0
+            else "Scan ready — press Tab to analyse"
+        )
+        text_y = self._draw_wrapped_text(
+            surface,
+            font,
+            panel_rect.x + 12,
+            text_y + 10,
+            scan_status,
+            (150, 205, 255),
+        )
+        text_y += 6
+        tasks = [task.progress_line() for task in self.active_tasks]
+        if not tasks:
+            tasks = ["Collect insights to unlock research tasks."]
+        text_y = self._draw_section(
+            surface,
+            font,
+            panel_rect.x + 12,
+            text_y,
+            "Research Tasks",
+            tasks[:5],
+        )
+        text_y = self._draw_section(
+            surface,
+            font,
+            panel_rect.x + 12,
+            text_y,
+            "Coaching",
+            list(self.coaching_tips),
+        )
         text_y = self._draw_section(
             surface, font, panel_rect.x + 12, text_y, "Messages", self.messages
         )
@@ -284,8 +754,74 @@ class Level:
             "Insights Logged",
             (f"{title}: {body}" for title, body in self.knowledge_log[-4:]),
         )
-        stats = f"Health: {self.player.health}\nEnergy: {int(self.player.energy)}/{int(self.player.max_energy)}"
-        self._draw_wrapped_text(surface, font, panel_rect.x + 12, height - 64, stats)
+        mastered = [
+            title
+            for title, record in self.research_journal.records.items()
+            if record.mastered
+        ]
+        if mastered:
+            text_y = self._draw_section(
+                surface,
+                font,
+                panel_rect.x + 12,
+                text_y,
+                "Mastered Concepts",
+                mastered,
+            )
+        self._draw_stat_bars(surface, font, panel_rect)
+
+    def _draw_stat_bars(self, surface: Any, font: Any, panel_rect: Any) -> None:
+        if pygame is None:
+            return
+        base_x = panel_rect.x + 12
+        health_max = getattr(self.player, "max_health", 5) or 5
+        self._draw_stat_bar(
+            surface,
+            font,
+            base_x,
+            panel_rect.bottom - 110,
+            "Health",
+            self.player.health,
+            health_max,
+            (255, 140, 140),
+            panel_rect.width - 24,
+        )
+        self._draw_stat_bar(
+            surface,
+            font,
+            base_x,
+            panel_rect.bottom - 60,
+            "Energy",
+            self.player.energy,
+            self.player.max_energy,
+            (120, 255, 220),
+            panel_rect.width - 24,
+        )
+
+    def _draw_stat_bar(
+        self,
+        surface: Any,
+        font: Any,
+        x: int,
+        y: int,
+        label: str,
+        value: float,
+        maximum: float,
+        colour: Tuple[int, int, int],
+        width: int,
+    ) -> None:
+        if pygame is None:
+            return
+        max_value = max(1.0, float(maximum))
+        ratio = max(0.0, min(1.0, float(value) / max_value))
+        bar_rect = pygame.Rect(x, y, width, 16)
+        pygame.draw.rect(surface, (28, 36, 60), bar_rect, border_radius=6)
+        fill_rect = pygame.Rect(x, y, int(width * ratio), 16)
+        pygame.draw.rect(surface, colour, fill_rect, border_radius=6)
+        label_surface = font.render(
+            f"{label}: {int(value)}/{int(max_value)}", True, (220, 225, 250)
+        )
+        surface.blit(label_surface, (x, y - label_surface.get_height() - 2))
 
     def _draw_section(
         self,

--- a/src/mech_arena/progression.py
+++ b/src/mech_arena/progression.py
@@ -1,0 +1,105 @@
+"""Persistence helpers for the player's long-term research progress."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List
+
+import json
+
+
+DEFAULT_JOURNAL_PATH = Path.home() / ".mechanistic_mech_journal.json"
+
+
+@dataclass
+class InsightRecord:
+    """Represents the player's familiarity with a single concept."""
+
+    title: str
+    summary: str
+    mastered: bool = False
+    tasks_completed: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "title": self.title,
+            "summary": self.summary,
+            "mastered": self.mastered,
+            "tasks_completed": list(self.tasks_completed),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "InsightRecord":
+        return cls(
+            title=str(payload.get("title", "")),
+            summary=str(payload.get("summary", "")),
+            mastered=bool(payload.get("mastered", False)),
+            tasks_completed=list(payload.get("tasks_completed", [])),
+        )
+
+
+@dataclass
+class ResearchJournal:
+    """Tracks discoveries across sessions and stores them on disk."""
+
+    records: Dict[str, InsightRecord] = field(default_factory=dict)
+    path: Path = DEFAULT_JOURNAL_PATH
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> "ResearchJournal":
+        real_path = path or DEFAULT_JOURNAL_PATH
+        try:
+            data = json.loads(real_path.read_text())
+        except FileNotFoundError:
+            return cls(path=real_path)
+        except Exception:
+            # Corrupt save files should not break the game; start fresh instead.
+            return cls(path=real_path)
+
+        records = {
+            title: InsightRecord.from_dict(payload) for title, payload in data.items()
+        }
+        return cls(records=records, path=real_path)
+
+    # ------------------------------------------------------------------
+    # Mutation helpers
+    # ------------------------------------------------------------------
+    def log_insight(self, title: str, summary: str) -> None:
+        record = self.records.get(title)
+        if record is None:
+            self.records[title] = InsightRecord(title=title, summary=summary)
+        else:
+            if summary and summary != record.summary:
+                record.summary = summary
+
+    def mark_task_completed(self, title: str, task_id: str) -> None:
+        record = self.records.setdefault(title, InsightRecord(title=title, summary=""))
+        if task_id not in record.tasks_completed:
+            record.tasks_completed.append(task_id)
+
+    def mark_mastered(self, title: str) -> None:
+        record = self.records.setdefault(title, InsightRecord(title=title, summary=""))
+        record.mastered = True
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+    def tasks_for(self, title: str) -> List[str]:
+        record = self.records.get(title)
+        return list(record.tasks_completed) if record else []
+
+    def is_mastered(self, title: str) -> bool:
+        record = self.records.get(title)
+        return bool(record and record.mastered)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+    def save(self) -> None:
+        try:
+            serialised = {k: v.to_dict() for k, v in self.records.items()}
+            self.path.write_text(json.dumps(serialised, indent=2, sort_keys=True))
+        except Exception:
+            # Ignore file-system errors in headless/testing environments.
+            return

--- a/src/mech_arena/tasks.py
+++ b/src/mech_arena/tasks.py
@@ -1,0 +1,128 @@
+"""Research task primitives that unlock deeper interpretability practice."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, List
+
+if False:  # pragma: no cover - imported only for typing during analysis
+    from .level import Level
+
+
+Condition = Callable[["Level"], bool]
+
+
+def _never(_: "Level") -> bool:
+    return False
+
+
+@dataclass
+class ResearchTask:
+    """A multi-step objective attached to a collected insight."""
+
+    identifier: str
+    concept: str
+    description: str
+    tip: str = ""
+    requirement: Condition = field(default_factory=lambda: _never)
+    completed: bool = False
+    requires_scan: bool = False
+
+    def evaluate(self, level: "Level") -> bool:
+        """Mark the task complete if its requirement now holds."""
+        if self.completed:
+            return False
+        if self.requirement(level):
+            self.completed = True
+            return True
+        return False
+
+    def progress_line(self) -> str:
+        status = "✓" if self.completed else "…"
+        return f"{status} {self.description}"
+
+
+def build_residual_tasks() -> List[ResearchTask]:
+    """Tasks that reinforce the residual stream concept."""
+
+    return [
+        ResearchTask(
+            identifier="residual_scan",
+            concept="Residual Stream",
+            description="Scan while the residual stream is linking allies.",
+            tip="Use Tab when it tethers to reveal how support flows.",
+            requirement=lambda level: bool(
+                level.scan_timer > 0 and level.analysis_tags.get("residual_linking")
+            ),
+            requires_scan=True,
+        ),
+        ResearchTask(
+            identifier="residual_ablate",
+            concept="Residual Stream",
+            description="Ablate the residual stream to watch buffs collapse.",
+            tip="Toggle analysis ablation with number keys while scanning.",
+            requirement=lambda level: level.analysis_tags.get(
+                "residual_ablation", False
+            ),
+        ),
+    ]
+
+
+def build_induction_tasks() -> List[ResearchTask]:
+    return [
+        ResearchTask(
+            identifier="induction_prediction",
+            concept="Induction Head",
+            description="Witness the token prediction arc during a scan.",
+            tip="Line up with the projected token beads.",
+            requirement=lambda level: bool(
+                level.scan_timer > 0 and level.analysis_tags.get("induction_prediction")
+            ),
+            requires_scan=True,
+        ),
+        ResearchTask(
+            identifier="induction_ablate",
+            concept="Induction Head",
+            description="Ablate the induction head after observing the pattern.",
+            tip="Press the matching number to freeze it mid-copy.",
+            requirement=lambda level: level.analysis_tags.get(
+                "induction_ablation", False
+            ),
+        ),
+    ]
+
+
+def build_circuit_tasks() -> List[ResearchTask]:
+    return [
+        ResearchTask(
+            identifier="circuit_overlap",
+            concept="Circuit Breaker",
+            description="Trigger a scan while two enemies share a circuit.",
+            tip="Wait until the breaker chains lightning between allies.",
+            requirement=lambda level: bool(
+                level.scan_timer > 0 and level.analysis_tags.get("circuit_chain")
+            ),
+            requires_scan=True,
+        ),
+        ResearchTask(
+            identifier="circuit_interrupt",
+            concept="Circuit Breaker",
+            description="Disrupt a charged circuit breaker via ablation.",
+            tip="Freeze it mid-charge to see the cascade stop.",
+            requirement=lambda level: level.analysis_tags.get(
+                "circuit_ablation", False
+            ),
+        ),
+    ]
+
+
+TASK_BUILDERS = {
+    "Residual Stream": build_residual_tasks,
+    "Induction Head": build_induction_tasks,
+    "Circuit Breaker": build_circuit_tasks,
+}
+
+
+def build_tasks_for(topic: str) -> Iterable[ResearchTask]:
+    factory = TASK_BUILDERS.get(topic)
+    return factory() if factory else []

--- a/tests/test_level.py
+++ b/tests/test_level.py
@@ -1,3 +1,5 @@
+import math
+
 from mech_arena.enemy import Enemy
 from mech_arena.level import Level
 from mech_arena.player import Player
@@ -34,11 +36,12 @@ def test_scan_consumes_energy_and_slows_enemies():
         height=400,
     )
     start_energy = player.energy
-    start_x = enemy.x
+    start_pos = (enemy.x, enemy.y)
     level.update(dt=1.0, trigger_scan=True)
     assert level.scan_timer > 0
     assert player.energy == start_energy - player.scan_cost
-    assert enemy.x > start_x - enemy.speed  # slower than full-speed drift
+    movement = math.hypot(enemy.x - start_pos[0], enemy.y - start_pos[1])
+    assert 0 < movement < enemy.speed  # slower than full-speed drift due to scan
     assert level.messages  # message logged
 
 
@@ -56,3 +59,40 @@ def test_messages_queue_keeps_recent_entries():
     for _ in range(10):
         level.add_message("Test message")
     assert len(level.messages) <= level.messages.maxlen
+
+
+def test_analysis_command_requires_scan_for_ablation():
+    player = Player(x=100, y=100)
+    enemy = Enemy(x=120, y=120, topic="Residual Stream", summary="")
+    level = Level(
+        name="analysis",
+        description="",
+        player=player,
+        enemies=[enemy],
+        width=500,
+        height=400,
+    )
+    # Without scan the ablation should not trigger.
+    level.update(dt=0.1, analysis_commands=[("toggle_ablation", 0)])
+    assert not enemy.ablated
+    # Activate scan timer and ensure ablation toggles.
+    level.scan_timer = 1.0
+    level.update(dt=0.1, analysis_commands=[("toggle_ablation", 0)])
+    assert enemy.ablated
+    assert level.analysis_tags.get("residual_ablation")
+
+
+def test_collecting_insight_unlocks_tasks_and_journal():
+    player = Player(x=0, y=0)
+    enemy = Enemy(x=0, y=0, topic="Residual Stream", summary="Test enemy", health=1)
+    level = Level(
+        name="research",
+        description="",
+        player=player,
+        enemies=[enemy],
+        width=500,
+        height=400,
+    )
+    level.update(dt=0.1, fire_target=player.center)
+    assert any(task.concept == "Residual Stream" for task in level.active_tasks)
+    assert "Residual Stream" in level.research_journal.records


### PR DESCRIPTION
## Summary
- make each subsystem exhibit concept-specific behaviour with scan-time ablation and patch controls
- persist discoveries in a research journal and unlock multi-step tasks plus coaching guidance when insights are collected
- upgrade the scan overlay, HUD, and arena visuals to showcase token patterns, latent links, and player status

## Testing
- black src tests
- pytest
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68c99706a65c8333b58176d4f4f1f053